### PR TITLE
Fix escape helper missing single quote handling

### DIFF
--- a/assets/cms-boot.js
+++ b/assets/cms-boot.js
@@ -1,5 +1,5 @@
 (function(){
-  const esc = s => String(s||'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m]));
+  const esc = s => String(s||'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
   const lang = localStorage.getItem('khotwa_lang') === 'en' ? 'en' : 'ar';
 
   async function getJSON(path, fallback){


### PR DESCRIPTION
## Summary
- handle single quotes in cms escape utility to avoid inserting "undefined"

## Testing
- `node - <<'NODE'
const esc = s => String(s||'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
console.log(esc("a'b"));
NODE`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b306521a98832083652dfa5ded5fa9